### PR TITLE
Allow all CORS origins on staging

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,6 +19,7 @@ review:
     K8S_SECRET_ALLOWED_HOSTS: "*"
     K8S_SECRET_DEBUG: 1
     K8S_SECRET_IMPORT_FEATURES: 1
+    K8S_SECRET_CORS_ORIGIN_ALLOW_ALL: 1
 
 staging:
   # By default the staging environment is created from the master-branch.
@@ -32,3 +33,4 @@ staging:
     K8S_SECRET_SECRET_KEY: "$GL_QA_DJANGO_SECRET_KEY"
     K8S_SECRET_TOKEN_AUTH_AUTHSERVER_URL: "https://tunnistamo.test.kuva.hel.ninja/openid"
     K8S_SECRET_IMPORT_FEATURES: 1
+    K8S_SECRET_CORS_ORIGIN_ALLOW_ALL: 1


### PR DESCRIPTION
This PR sets all cors origins as allowed on staging environment.