### PR TITLE
Always enable graphiql

### DIFF
--- a/ahti/urls.py
+++ b/ahti/urls.py
@@ -4,11 +4,9 @@ from django.views.decorators.csrf import csrf_exempt
 from graphene_django.views import GraphQLView
 from helusers.admin_site import admin
 
-from ahti import settings
-
 urlpatterns = [
     path("admin/", admin.site.urls),
-    path("graphql", csrf_exempt(GraphQLView.as_view(graphiql=settings.DEBUG))),
+    path("graphql", csrf_exempt(GraphQLView.as_view(graphiql=True))),
 ]
 
 


### PR DESCRIPTION
This PR sets graphiql interface as always enabled i.e. it will be enabled in production environments.