### PR TITLE
Bump Django version to 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 branches: {only: [master, develop]}
+dist: bionic
 sudo: false
 language: python
 python: 3.8

--- a/ahti/settings.py
+++ b/ahti/settings.py
@@ -3,7 +3,7 @@ import subprocess
 
 import environ
 import sentry_sdk
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from sentry_sdk.integrations.django import DjangoIntegration
 
 checkout_dir = environ.Path(__file__) - 2

--- a/features/apps.py
+++ b/features/apps.py
@@ -1,5 +1,5 @@
 from django.apps import AppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class FeaturesConfig(AppConfig):

--- a/features/importers/dummy/apps.py
+++ b/features/importers/dummy/apps.py
@@ -1,5 +1,5 @@
 from django.apps import AppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class DummyConfig(AppConfig):

--- a/features/importers/myhelsinki_places/apps.py
+++ b/features/importers/myhelsinki_places/apps.py
@@ -1,5 +1,5 @@
 from django.apps import AppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class MyHelsinkiPlacesConfig(AppConfig):

--- a/features/models.py
+++ b/features/models.py
@@ -1,5 +1,5 @@
 from django.contrib.gis.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from parler.models import TranslatableModel, TranslatedFields
 from utils.models import TimestampedModel
 

--- a/features/schema.py
+++ b/features/schema.py
@@ -56,7 +56,7 @@ class Image(DjangoObjectType):
 class License(DjangoObjectType):
     class Meta:
         model = models.License
-        fields = ("name",)
+        fields = ("id",)
 
     name = graphene.String(required=True)
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,54 +11,54 @@ black==19.10b0
 certifi==2019.11.28       # via requests
 chardet==3.0.4            # via requests
 click==7.0                # via black
-coverage==4.5.4           # via pytest-cov
+coverage==5.0.3           # via pytest-cov
 decorator==4.4.1          # via ipython, traitlets
 entrypoints==0.3          # via flake8
 factory-boy==2.12.0
-faker==3.0.0              # via factory-boy
+faker==4.0.0              # via factory-boy
 fastdiff==0.2.0           # via snapshottest
 flake8==3.7.9
-freezegun==0.3.12
+freezegun==0.3.13
 idna==2.8                 # via requests
-importlib-metadata==1.2.0  # via pluggy, pytest
+importlib-metadata==1.4.0  # via pluggy, pytest
 ipython-genutils==0.2.0   # via traitlets
-ipython==7.10.1
+ipython==7.11.1
 isort==4.3.21
-jedi==0.15.1              # via ipython
+jedi==0.15.2              # via ipython
 mccabe==0.6.1             # via flake8
-more-itertools==8.0.2     # via pytest, zipp
-packaging==19.2           # via pytest
-parso==0.5.1              # via jedi
-pathspec==0.6.0           # via black
+more-itertools==8.1.0     # via pytest, zipp
+packaging==20.0           # via pytest
+parso==0.5.2              # via jedi
+pathspec==0.7.0           # via black
 pexpect==4.7.0            # via ipython
 pickleshare==0.7.5        # via ipython
 pluggy==0.13.1            # via pytest
 prompt-toolkit==3.0.2     # via ipython
 ptyprocess==0.6.0         # via pexpect
-py==1.8.0                 # via pytest
+py==1.8.1                 # via pytest
 pycodestyle==2.5.0        # via flake8
 pyflakes==2.1.1           # via flake8
 pygments==2.5.2           # via ipython
-pyparsing==2.4.5          # via packaging
+pyparsing==2.4.6          # via packaging
 pytest-cov==2.8.1
-pytest-django==3.7.0
-pytest-mock==1.13.0
-pytest==5.3.1
+pytest-django==3.8.0
+pytest-mock==2.0.0
+pytest==5.3.2
 python-dateutil==2.8.1    # via faker, freezegun
-regex==2019.12.9          # via black
+regex==2020.1.8           # via black
 requests-mock==1.7.0
 requests==2.22.0          # via requests-mock
-six==1.13.0               # via faker, freezegun, packaging, python-dateutil, requests-mock, snapshottest, traitlets
+six==1.14.0               # via freezegun, packaging, python-dateutil, requests-mock, snapshottest, traitlets
 snapshottest==0.5.1
 termcolor==1.1.0          # via snapshottest
 text-unidecode==1.3       # via faker
 toml==0.10.0              # via black
 traitlets==4.3.3          # via ipython
-typed-ast==1.4.0          # via black
+typed-ast==1.4.1          # via black
 urllib3==1.25.7           # via requests
 wasmer==0.3.0             # via fastdiff
-wcwidth==0.1.7            # via prompt-toolkit, pytest
-zipp==0.6.0               # via importlib-metadata
+wcwidth==0.1.8            # via prompt-toolkit, pytest
+zipp==1.0.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,39 +5,40 @@
 #    pip-compile requirements.in
 #
 aniso8601==7.0.0          # via graphene
+asgiref==3.2.3            # via django
 certifi==2019.11.28       # via requests, sentry-sdk
 chardet==3.0.4            # via requests
-django-cors-headers==3.2.0
+django-cors-headers==3.2.1
 django-environ==0.4.5
 django-filter==2.2.0
 django-graphql-geojson==0.1.4
 django-graphql-jwt==0.3.0
 django-helusers==0.5.2
-django-parler==2.0
-django==2.2.8
-djangorestframework==3.10.3  # via drf-oidc-auth
+django-parler==2.0.1
+django==3.0.2
+djangorestframework==3.11.0  # via drf-oidc-auth
 drf-oidc-auth==0.9        # via django-helusers
-ecdsa==0.14.1             # via python-jose
-future==0.18.2            # via pyjwkest, python-jose
-graphene-django==2.7.1
+ecdsa==0.15               # via python-jose
+future==0.18.2            # via pyjwkest
+graphene-django==2.8.0
 graphene==2.1.8           # via graphene-django
 graphql-core==2.2.1       # via django-graphql-jwt, graphene, graphene-django, graphql-relay
 graphql-relay==2.0.1      # via graphene
 idna==2.8                 # via requests
 jmespath==0.9.4
-promise==2.2.1            # via graphene-django, graphql-core, graphql-relay
+promise==2.3              # via graphene-django, graphql-core, graphql-relay
 psycopg2==2.8.4
-pyasn1==0.4.8             # via rsa
+pyasn1==0.4.8             # via python-jose, rsa
 pycryptodomex==3.9.4      # via pyjwkest
 pyjwkest==1.4.2           # via drf-oidc-auth
 pyjwt==1.7.1              # via django-graphql-jwt
-python-jose==3.0.1        # via django-helusers
+python-jose==3.1.0        # via django-helusers
 pytz==2019.3              # via django
 requests==2.22.0
 rsa==4.0                  # via python-jose
 rx==1.6.1                 # via graphql-core
-sentry-sdk==0.13.5
+sentry-sdk==0.14.0
 singledispatch==3.4.0.3   # via graphene-django
-six==1.13.0               # via ecdsa, graphene, graphene-django, graphql-core, graphql-relay, promise, pyjwkest, python-jose, singledispatch
+six==1.14.0               # via django-parler, ecdsa, graphene, graphene-django, graphql-core, graphql-relay, promise, pyjwkest, python-jose, singledispatch
 sqlparse==0.3.0           # via django
 urllib3==1.25.7           # via requests, sentry-sdk

--- a/users/apps.py
+++ b/users/apps.py
@@ -1,5 +1,5 @@
 from django.apps import AppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class UsersConfig(AppConfig):

--- a/users/models.py
+++ b/users/models.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from helusers.models import AbstractUser
 
 

--- a/utils/models.py
+++ b/utils/models.py
@@ -1,5 +1,5 @@
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class TimestampedModel(models.Model):


### PR DESCRIPTION
This PR updates most of the projects packages into a more recent version.

Django 3.0 provides e.g. an improved way of doing enumerations for model field choices.