### PR TITLE
Use Finnish as django-parler default/fallback

### DIFF
--- a/ahti/settings.py
+++ b/ahti/settings.py
@@ -154,7 +154,7 @@ OIDC_API_TOKEN_AUTH = {
 DEFAULT_SRID = 4326  # WGS84
 
 PARLER_LANGUAGES = {None: ({"code": "fi"}, {"code": "sv"}, {"code": "en"})}
-PARLER_DEFAULT_LANGUAGE_CODE = "en"
+PARLER_DEFAULT_LANGUAGE_CODE = "fi"
 
 GRAPHENE = {
     "SCHEMA": "ahti.schema.schema",

--- a/features/schema.py
+++ b/features/schema.py
@@ -86,7 +86,7 @@ class Feature(graphql_geojson.GeoJSONType):
 
     ahti_id = graphene.String(required=True)
     source = graphene.Field(FeatureSource, required=True)
-    name = graphene.String()
+    name = graphene.String(required=True)
     description = graphene.String()
     url = graphene.String()
     modified_at = graphene.DateTime(required=True)


### PR DESCRIPTION
Since currently only Finnish is imported it makes sense
to use it as default fallback language so that null is not returened
from the API.

Also make features name a required attribute in the GQL API.