### PR TITLE
AHTI-44 | Improve configuration for MyHelsinki Places importer

### DIFF
--- a/features/importers/myhelsinki_places/app_settings.py
+++ b/features/importers/myhelsinki_places/app_settings.py
@@ -1,0 +1,89 @@
+import json
+import sys
+from pathlib import PurePath
+from typing import Iterable, Mapping
+
+
+class AppSettings:
+    """Overridable app settings.
+
+    Default settings for the app come from a JSON file. Settings can be overridden
+    with Django settings.
+    """
+
+    def __init__(self, prefix: str, config: Mapping):
+        self.prefix = prefix
+        self.config = config
+
+    def _setting(self, name, dflt):
+        from django.conf import settings
+
+        return getattr(settings, self.prefix + name, dflt)
+
+    @property
+    def API_CALLS(self) -> Iterable[Mapping]:
+        """Calls and parameters which will be sent to the API.
+
+        Query parameters: http://open-api.myhelsinki.fi/doc#/v1places/listAll
+
+        Example:
+        api_calls = [
+            {"tags_search": ["Island"]},  # matko2:47 Island
+            {"distance_filter": "60.1443, 24.9848, 1"},  # Suomenlinna
+        ]
+        """
+        return self._setting("API_CALLS", self.config["api_calls"])
+
+    @property
+    def TAG_CONFIG(self) -> Mapping:
+        """Tag mapping configuration.
+
+        Define how external tags are mapped into internal tags using
+        mapping and whitelisting rules.
+
+        Example:
+        tag_config = {
+            "rules": [{"mapped_names": ["Island"], "id": "island", "name": "saaristo"}],
+            "whitelist": [],
+        }
+        """
+        return self._setting("TAG_CONFIG", self.config["tag_config"])
+
+    @property
+    def CATEGORY_CONFIG(self) -> Mapping:
+        """Category mapping configuration.
+
+        Define how imported features are mapped into categories.
+
+        Example:
+        category_config = {
+            "rules": [
+                {"mapped_names": ["Island"], "id": "island", "name": "Saaret"}
+            ],
+        }
+        """
+        return self._setting("CATEGORY_CONFIG", self.config["category_config"])
+
+    @property
+    def ALLOWED_IMAGE_LICENSES(self) -> Iterable[str]:
+        """Only images with the given licenses should imported.
+
+        Example:
+        allowed_image_licenses = ["All rights reserved.", "MyHelsinki license type A"]
+        """
+        return self._setting(
+            "ALLOWED_IMAGE_LICENSES", self.config["allowed_image_licenses"]
+        )
+
+
+path = PurePath(__file__).parent.joinpath("config.json")
+with open(path.as_posix(), "r") as f:
+    config = json.loads(f.read())
+
+# Ugly? Guido recommends this himself ...
+# http://mail.python.org/pipermail/python-ideas/2012-May/014969.html
+
+app_settings = AppSettings("MYHELSINKI_PLACES_", config)
+app_settings.__name__ = __name__
+app_settings.__file__ = __file__
+sys.modules[__name__] = app_settings

--- a/features/importers/myhelsinki_places/config.json
+++ b/features/importers/myhelsinki_places/config.json
@@ -1,0 +1,15 @@
+{
+  "api_calls":  [
+    {"tags_search": ["Island"]},
+    {"distance_filter": "60.1346, 25.0112, 1.2"},
+    {"distance_filter": "60.1443, 24.9848, 1"}
+  ],
+  "tag_config": {
+    "rules": [{"mapped_names": ["Island"], "id": "island", "name": "saaristo"}],
+    "whitelist": []
+  },
+  "category_config": {
+    "rules": [{"mapped_names": ["Island"], "id": "island", "name": "Saaret"}]
+  },
+  "allowed_image_licenses": ["All rights reserved.", "MyHelsinki license type A"]
+}

--- a/features/importers/myhelsinki_places/config.json
+++ b/features/importers/myhelsinki_places/config.json
@@ -1,8 +1,6 @@
 {
   "api_calls":  [
-    {"tags_search": ["Island"]},
-    {"distance_filter": "60.1346, 25.0112, 1.2"},
-    {"distance_filter": "60.1443, 24.9848, 1"}
+    {}
   ],
   "tag_config": {
     "rules": [{"mapped_names": ["Island"], "id": "island", "name": "saaristo"}],

--- a/features/importers/myhelsinki_places/tests/conftest.py
+++ b/features/importers/myhelsinki_places/tests/conftest.py
@@ -11,11 +11,16 @@ def autouse_db(db):
     pass
 
 
+@pytest.fixture(autouse=True)
+def setup_test_environment(settings):
+    settings.MYHELSINKI_PLACES_API_CALLS = [
+        {}
+    ]  # Response is mocked, parameters are redundant
+
+
 @pytest.fixture
 def importer():
-    mhi = MyHelsinkiImporter()
-    mhi.api_calls = [{}]  # Response is mocked, parameters are redundant
-    return mhi
+    return MyHelsinkiImporter()
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR moves the importer configuration away from the code. Also filtering is adjusted so that for now importer will import everything from the API and filtering/mapping rules will be adjusted later as needed.

* Move configuration of the importer into a JSON file.
* Allow overriding the settings with Django settings (e.g. for testing).