### PR TITLE
Import features after migrations have been run in production

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,7 +19,6 @@ review:
     K8S_SECRET_ALLOWED_HOSTS: "*"
     K8S_SECRET_CORS_ORIGIN_ALLOW_ALL: 1
     K8S_SECRET_DEBUG: 1
-    K8S_SECRET_IMPORT_FEATURES: 1
 
 staging:
   # By default the staging environment is created from the master-branch.
@@ -31,7 +30,6 @@ staging:
   variables:
     K8S_SECRET_ALLOWED_HOSTS: "*"
     K8S_SECRET_CORS_ORIGIN_ALLOW_ALL: 1
-    K8S_SECRET_IMPORT_FEATURES: 1
     K8S_SECRET_SECRET_KEY: "$GL_QA_DJANGO_SECRET_KEY"
     K8S_SECRET_SKIP_DATABASE_CHECK: 1
     K8S_SECRET_TOKEN_AUTH_AUTHSERVER_URL: "https://tunnistamo.test.kuva.hel.ninja/openid"

--- a/.prod/on_deploy.sh
+++ b/.prod/on_deploy.sh
@@ -2,3 +2,4 @@
 set -e
 
 ./manage.py migrate --noinput
+./manage.py import_features

--- a/features/importers/myhelsinki_places/config.json
+++ b/features/importers/myhelsinki_places/config.json
@@ -1,6 +1,6 @@
 {
   "api_calls":  [
-    {}
+    {"tags_search": ["Island"]}
   ],
   "tag_config": {
     "rules": [{"mapped_names": ["Island"], "id": "island", "name": "saaristo"}],


### PR DESCRIPTION
Docker entrypoint ran before `on_deploy.sh` which tried to import features before migrations had been run.

Also avoid causing a timeout on the deployment pipeline when importing all features. This is fixed by temporarily not importing everything.