### PR TITLE
AHTI-44 | Use uWSGI cron to import all features

### DIFF
--- a/.prod/on_deploy.sh
+++ b/.prod/on_deploy.sh
@@ -2,4 +2,3 @@
 set -e
 
 ./manage.py migrate --noinput
-./manage.py import_features

--- a/.prod/uwsgi.ini
+++ b/.prod/uwsgi.ini
@@ -8,3 +8,4 @@ gid = appuser
 master = 1
 processes = 2
 threads = 2
+cron = 45 -1 -1 -1 -1 /app/manage.py import_features

--- a/features/importers/myhelsinki_places/config.json
+++ b/features/importers/myhelsinki_places/config.json
@@ -1,6 +1,6 @@
 {
   "api_calls":  [
-    {"tags_search": ["Island"]}
+    {}
   ],
   "tag_config": {
     "rules": [{"mapped_names": ["Island"], "id": "island", "name": "saaristo"}],

--- a/features/management/commands/import_features.py
+++ b/features/management/commands/import_features.py
@@ -1,8 +1,11 @@
+import logging
 import sys
 
 from django.core.management.base import BaseCommand
 
 from features.importers.registry import importers
+
+logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
@@ -28,6 +31,11 @@ class Command(BaseCommand):
 
         for identifier, importer_class in enabled_importers:
             self.stdout.write(self.style.SUCCESS(f"Importing {identifier}"))
-            importer_class().import_features()
+            try:
+                importer_class().import_features()
+            except Exception:
+                message = f"Importer {importer_class} failed to import data"
+                logging.exception(message)
+                self.stderr.write(self.style.ERROR(message))
 
         self.stdout.write(self.style.SUCCESS("Feature importers completed"))


### PR DESCRIPTION
Production/PR deployment runs have a strict 3 minute timeout on them. This means that running any long running jobs during them is not feasible. Since there's no access to a job queue (like celery or RQ) yet, we'll use cron feature provided by uWSGI instead.