### PR TITLE
Add debug middleware and GQL API provided by graphene-django

### DIFF
--- a/ahti/schema.py
+++ b/ahti/schema.py
@@ -1,11 +1,15 @@
 import graphene
+from django.conf import settings
+from graphene_django.debug import DjangoDebug
 
 import categories.schema
 import features.schema
 
-
-class Query(features.schema.Query, categories.schema.Query, graphene.ObjectType):
-    pass
+Query = type(
+    "Query",
+    (features.schema.Query, categories.schema.Query, graphene.ObjectType),
+    {"debug": graphene.Field(DjangoDebug, name="_debug")} if settings.DEBUG else {},
+)
 
 
 schema = graphene.Schema(query=Query)

--- a/ahti/settings.py
+++ b/ahti/settings.py
@@ -161,6 +161,9 @@ GRAPHENE = {
     "SCHEMA": "ahti.schema.schema",
     "MIDDLEWARE": ["graphql_jwt.middleware.JSONWebTokenMiddleware"],
 }
+if DEBUG:
+    GRAPHENE["MIDDLEWARE"].append("graphene_django.debug.DjangoDebugMiddleware")
+
 
 GRAPHQL_JWT = {"JWT_AUTH_HEADER_PREFIX": "Bearer"}
 


### PR DESCRIPTION
This PR adds the debugging facility provided by graphene-django. Debugging middleware and API are only used if `DEBUG` setting is enabled.

Refs: https://docs.graphene-python.org/projects/django/en/latest/debug/