### PR TITLE
AHTI-240 | Remove identifier prefixes from the mapped categories and tags

### DIFF
--- a/features/importers/base.py
+++ b/features/importers/base.py
@@ -81,7 +81,6 @@ class TagMapper(MapperBase):
     Only tags defined in the configuration will be considered.
     """
 
-    internal_tag_prefix = "ahti:tag:"
     whitelist = True
 
     def get_tag(self, tag: dict) -> Optional[Tag]:
@@ -104,8 +103,7 @@ class TagMapper(MapperBase):
         mapping = self.config.get(tag["name"].lower())
         if mapping:
             tag, created = Tag.objects.language("fi").update_or_create(
-                id=f"{self.internal_tag_prefix}{mapping['id']}",
-                defaults={"name": mapping["name"]},
+                id=mapping["id"], defaults={"name": mapping["name"]},
             )
             return tag
 
@@ -121,8 +119,6 @@ class CategoryMapper(MapperBase):
     will be considered.
     """
 
-    internal_category_prefix = "ahti:category:"
-
     def get_category(self, category: dict) -> Optional[Category]:
         """Return a Category instance for the given input.
 
@@ -134,7 +130,6 @@ class CategoryMapper(MapperBase):
         mapping = self.config.get(category["name"].lower())
         if mapping:
             category, created = Category.objects.language("fi").update_or_create(
-                id=f"{self.internal_category_prefix}{mapping['id']}",
-                defaults={"name": mapping["name"]},
+                id=mapping["id"], defaults={"name": mapping["name"]},
             )
             return category

--- a/features/importers/myhelsinki_places/app_settings.py
+++ b/features/importers/myhelsinki_places/app_settings.py
@@ -43,7 +43,13 @@ class AppSettings:
 
         Example:
         tag_config = {
-            "rules": [{"mapped_names": ["Island"], "id": "island", "name": "saaristo"}],
+            "rules": [
+                {
+                    "mapped_names": ["Island"],
+                    "id": "ahti:tag:island",
+                    "name": "saaristo"
+                },
+            ],
             "whitelist": [],
         }
         """
@@ -58,7 +64,11 @@ class AppSettings:
         Example:
         category_config = {
             "rules": [
-                {"mapped_names": ["Island"], "id": "island", "name": "Saaret"}
+                {
+                    "mapped_names": ["Island"],
+                    "id": "ahti:category:island",
+                    "name": "Saaret",
+                },
             ],
         }
         """

--- a/features/importers/myhelsinki_places/config.json
+++ b/features/importers/myhelsinki_places/config.json
@@ -3,11 +3,11 @@
     {}
   ],
   "tag_config": {
-    "rules": [{"mapped_names": ["Island"], "id": "island", "name": "saaristo"}],
+    "rules": [{"mapped_names": ["Island"], "id": "ahti:tag:island", "name": "saaristo"}],
     "whitelist": []
   },
   "category_config": {
-    "rules": [{"mapped_names": ["Island"], "id": "island", "name": "Saaret"}]
+    "rules": [{"mapped_names": ["Island"], "id": "ahti:category:island", "name": "Saaret"}]
   },
   "allowed_image_licenses": ["All rights reserved.", "MyHelsinki license type A"]
 }

--- a/features/importers/myhelsinki_places/tests/test_import_categories.py
+++ b/features/importers/myhelsinki_places/tests/test_import_categories.py
@@ -25,7 +25,6 @@ def test_import_feature_category(requests_mock, importer, places_response):
     importer.import_features()
 
     f = Feature.objects.get(source_id=2792)
-
     assert Category.objects.count() == 1
     assert f.category.pk == "ahti:category:island"
     assert f.category.name == "Saaret"
@@ -40,10 +39,10 @@ def test_category_is_not_set_when_no_mapping_matches(
         "rules": [{"mapped_names": ["nope"], "id": "nope", "name": "Nope"}],
     }
     importer = MyHelsinkiImporter()
+
     importer.import_features()
 
     f = Feature.objects.get(source_id=2792)
-
     assert not f.category
     assert Category.objects.count() == 0
 
@@ -51,7 +50,6 @@ def test_category_is_not_set_when_no_mapping_matches(
 def test_feature_category_is_not_updated(requests_mock, importer, places_response):
     """If a feature already has a category, import must not change it."""
     requests_mock.get(PLACES_URL, json=places_response)
-
     category = CategoryFactory()
     f = FeatureFactory(
         source_type=importer.get_source_type(), source_id="2792", category=category,

--- a/features/importers/myhelsinki_places/tests/test_import_categories.py
+++ b/features/importers/myhelsinki_places/tests/test_import_categories.py
@@ -14,7 +14,7 @@ PLACES_URL = MyHelsinkiPlacesClient.base_url + MyHelsinkiPlacesClient.places_url
 
 
 @pytest.fixture(autouse=True)
-def setup_images(settings):
+def setup_categories(settings):
     settings.MYHELSINKI_PLACES_CATEGORY_CONFIG = {
         "rules": [{"mapped_names": ["Island"], "id": "island", "name": "Saaret"}],
     }

--- a/features/importers/myhelsinki_places/tests/test_import_categories.py
+++ b/features/importers/myhelsinki_places/tests/test_import_categories.py
@@ -15,7 +15,9 @@ PLACES_URL = MyHelsinkiPlacesClient.base_url + MyHelsinkiPlacesClient.places_url
 @pytest.fixture(autouse=True)
 def setup_categories(settings):
     settings.MYHELSINKI_PLACES_CATEGORY_CONFIG = {
-        "rules": [{"mapped_names": ["Island"], "id": "island", "name": "Saaret"}],
+        "rules": [
+            {"mapped_names": ["Island"], "id": "ahti:category:island", "name": "Saaret"}
+        ],
     }
 
 

--- a/features/importers/myhelsinki_places/tests/test_import_categories.py
+++ b/features/importers/myhelsinki_places/tests/test_import_categories.py
@@ -2,7 +2,6 @@ import pytest
 
 from categories.models import Category
 from categories.tests.factories import CategoryFactory
-from features.importers.base import CategoryMapper
 from features.importers.myhelsinki_places.importer import (
     MyHelsinkiImporter,
     MyHelsinkiPlacesClient,
@@ -22,10 +21,6 @@ def setup_categories(settings):
 
 def test_import_feature_category(requests_mock, importer, places_response):
     requests_mock.get(PLACES_URL, json=places_response)
-    category_config = {
-        "rules": [{"mapped_names": ["Island"], "id": "island", "name": "Saaret"}],
-    }
-    importer.category_mapper = CategoryMapper(category_config)
 
     importer.import_features()
 

--- a/features/importers/myhelsinki_places/tests/test_import_tags.py
+++ b/features/importers/myhelsinki_places/tests/test_import_tags.py
@@ -24,7 +24,9 @@ def test_tags_are_imported_based_on_mapping_rules(
     """Importing tags from external source into internal tags."""
     requests_mock.get(PLACES_URL, json=places_response)
     tag_config = {
-        "rules": [{"mapped_names": ["Island"], "id": "island", "name": "saaristo"}],
+        "rules": [
+            {"mapped_names": ["Island"], "id": "ahti:tag:island", "name": "saaristo"}
+        ],
     }
     importer.tag_mapper = TagMapper(tag_config)
 

--- a/features/tests/test_category_mapper.py
+++ b/features/tests/test_category_mapper.py
@@ -17,7 +17,13 @@ from features.importers.base import CategoryMapper
 def test_category_mapping_rules(mapped_names, expected):
     data = {"id": "matko2:47", "name": "Island"}
     config = {
-        "rules": [{"mapped_names": mapped_names, "id": "island", "name": "Saaret"}],
+        "rules": [
+            {
+                "mapped_names": mapped_names,
+                "id": "ahti:category:island",
+                "name": "Saaret",
+            }
+        ],
     }
     mapper = CategoryMapper(config)
 

--- a/features/tests/test_tag_mapper.py
+++ b/features/tests/test_tag_mapper.py
@@ -47,7 +47,9 @@ def test_tag_mapping_whitelist(whitelist, expected):
 def test_tag_mapping_rules(mapped_names, expected):
     data = {"id": "matko2:47", "name": "Island"}
     config = {
-        "rules": [{"mapped_names": mapped_names, "id": "island", "name": "saaristo"}],
+        "rules": [
+            {"mapped_names": mapped_names, "id": "ahti:tag:island", "name": "saaristo"}
+        ],
     }
     mapper = TagMapper(config)
 


### PR DESCRIPTION
Tag and Category identifiers were assigned a prefix when  tag or a category was mapped to an internal one. Now the identifier for the objects need to be explicit in the mapping configuration.

Refs AHTI-240