### PR TITLE
AHTI-269 | Add production environment GitLab CI configuration

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -48,3 +48,5 @@ production:
     K8S_SECRET_TOKEN_AUTH_AUTHSERVER_URL: "https://api.hel.fi/sso/openid"
     K8S_SECRET_SENTRY_DSN: "$GL_SENTRY_DSN"
     K8S_SECRET_SENTRY_ENVIRONMENT: "production"
+    # Disable indexing for now
+    K8S_INGRESS_PREVENT_ROBOTS: 1

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,3 +36,15 @@ staging:
     K8S_SECRET_TOKEN_AUTH_AUTHSERVER_URL: "https://tunnistamo.test.kuva.hel.ninja/openid"
     K8S_SECRET_SENTRY_DSN: "$GL_SENTRY_DSN"
     K8S_SECRET_SENTRY_ENVIRONMENT: "staging"
+
+production:
+  # These variables are available only for production env and are merged with the general variables defined above.
+  variables:
+    K8S_SECRET_ALLOWED_HOSTS: "*"
+    K8S_SECRET_CORS_ORIGIN_ALLOW_ALL: 1
+    K8S_SECRET_SECRET_KEY: "$GL_PRODUCTION_DJANGO_SECRET_KEY"
+    K8S_SECRET_SKIP_DATABASE_CHECK: 1
+    K8S_SECRET_CREATE_SUPERUSER: 1
+    K8S_SECRET_TOKEN_AUTH_AUTHSERVER_URL: "https://api.hel.fi/sso/openid"
+    K8S_SECRET_SENTRY_DSN: "$GL_SENTRY_DSN"
+    K8S_SECRET_SENTRY_ENVIRONMENT: "production"


### PR DESCRIPTION
This PR adds configuration for the production environment.

**Note** Production environment is only deployed after code has been merged and tagged in `master` branch.