### PR TITLE
AHTI-172 | Django admin opening hours related improvements

### DIFF
--- a/features/admin.py
+++ b/features/admin.py
@@ -38,8 +38,10 @@ class LinkInline(admin.TabularInline):
 
 class OpeningHourInline(admin.TabularInline):
     model = OpeningHours
-    min_num = 7
-    extra = 0
+    extra = 7
+
+    def get_extra(self, request, obj=None, **kwargs):
+        return self.extra - obj.opening_hours.count() if obj else self.extra
 
 
 class OpeningHoursPeriodInline(TranslatableTabularInline):

--- a/features/models.py
+++ b/features/models.py
@@ -1,4 +1,5 @@
 from django.contrib.gis.db import models
+from django.utils.translation import gettext
 from django.utils.translation import gettext_lazy as _
 from parler.managers import TranslatableQuerySet
 from parler.models import TranslatableModel, TranslatedFields
@@ -320,6 +321,15 @@ class OpeningHours(models.Model):
         verbose_name = _("opening hours")
         verbose_name_plural = _("opening hours")
         ordering = ("id",)
+
+    def __str__(self):
+        if self.all_day:
+            hours_string = gettext("all day")
+        else:
+            opens_string = self.opens.strftime("%H.%M") if self.opens else ""
+            closes_string = self.closes.strftime("%H.%M") if self.closes else ""
+            hours_string = f"{opens_string}–{closes_string}"
+        return f"{gettext(Weekday(self.day).label)}: {hours_string}"
 
 
 class Override(TranslatableModel, TimestampedModel):

--- a/features/models.py
+++ b/features/models.py
@@ -298,6 +298,11 @@ class OpeningHoursPeriod(TranslatableModel):
         verbose_name_plural = _("opening hours periods")
         ordering = ("id",)
 
+    def __str__(self):
+        return ", ".join(
+            [str(oh) for oh in self.opening_hours.all().order_by("day", "opens")]
+        )
+
 
 class OpeningHours(models.Model):
     period = models.ForeignKey(


### PR DESCRIPTION
This PR adds some prettier strings for the opening hours into django admin and also allows the user to input a desired number of opening hours without requiring opening hours for the whole week.