### PR TITLE
AHTI-372 | Add tags query to the GQL API

### DIFF
--- a/categories/schema.py
+++ b/categories/schema.py
@@ -1,4 +1,5 @@
 import graphene
+from django.utils.translation import gettext_lazy as _
 from graphene_django import DjangoObjectType
 
 from categories import models
@@ -17,7 +18,9 @@ class FeatureCategory(DjangoObjectType):
 
 
 class Query(graphene.ObjectType):
-    feature_categories = graphene.List(FeatureCategory)
+    feature_categories = graphene.List(
+        FeatureCategory, description=_("Retrieve all categories")
+    )
 
     def resolve_feature_categories(self, info, **kwargs):
         return models.Category.objects.all()

--- a/features/schema.py
+++ b/features/schema.py
@@ -99,7 +99,7 @@ class License(DjangoObjectType):
 class Tag(DjangoObjectType):
     class Meta:
         model = models.Tag
-        fields = ("id",)
+        fields = ("id", "features")
 
     name = graphene.String(required=True)
 

--- a/features/schema.py
+++ b/features/schema.py
@@ -264,13 +264,16 @@ class Feature(graphql_geojson.GeoJSONType):
 
 
 class Query(graphene.ObjectType):
-    features = DjangoFilterConnectionField(Feature)
+    features = DjangoFilterConnectionField(
+        Feature, description=_("Retrieve all features matching the given filters")
+    )
     feature = graphene.Field(
         Feature,
         id=ID(description=_("The ID of the object")),
         ahti_id=String(description=_("Ahti ID of the object")),
+        description=_("Retrieve a single feature"),
     )
-    tags = graphene.List(Tag)
+    tags = graphene.List(Tag, description=_("Retrieve all tags"))
 
     def resolve_feature(self, info, id=None, ahti_id=None, **kwargs):
         if id:

--- a/features/schema.py
+++ b/features/schema.py
@@ -270,6 +270,7 @@ class Query(graphene.ObjectType):
         id=ID(description=_("The ID of the object")),
         ahti_id=String(description=_("Ahti ID of the object")),
     )
+    tags = graphene.List(Tag)
 
     def resolve_feature(self, info, id=None, ahti_id=None, **kwargs):
         if id:
@@ -282,3 +283,6 @@ class Query(graphene.ObjectType):
             except models.Feature.DoesNotExist:
                 return None
         raise GraphQLError("You must provide either `id` or `ahtiId`.")
+
+    def resolve_tags(self, info, **kwargs):
+        return models.Tag.objects.all()

--- a/features/tests/snapshots/snap_test_api.py
+++ b/features/tests/snapshots/snap_test_api.py
@@ -275,3 +275,23 @@ snapshots["test_feature_teaser 1"] = {
         }
     }
 }
+
+snapshots["test_tags_query 1"] = {
+    "data": {
+        "tags": [{"id": "tag:1", "name": "Tag 1"}, {"id": "tag:2", "name": "Tag 2"}]
+    }
+}
+
+snapshots["test_query_features_through_tags_query 1"] = {
+    "data": {
+        "tags": [
+            {
+                "features": {
+                    "edges": [{"node": {"properties": {"ahtiId": "test:test:sid0"}}}]
+                },
+                "id": "tag:1",
+                "name": "Tag 1",
+            }
+        ]
+    }
+}

--- a/features/tests/test_api.py
+++ b/features/tests/test_api.py
@@ -514,3 +514,47 @@ def test_feature_query_error(snapshot, api_client):
     """
     )
     snapshot.assert_match(executed)
+
+
+def test_tags_query(snapshot, api_client):
+    TagFactory(id="tag:1", name="Tag 1")
+    TagFactory(id="tag:2", name="Tag 2")
+
+    executed = api_client.execute(
+        """
+    query Tags {
+      tags {
+        id
+        name
+      }
+    }
+    """
+    )
+    snapshot.assert_match(executed)
+
+
+def test_query_features_through_tags_query(snapshot, api_client):
+    st = SourceTypeFactory(system="test", type="test")
+    feature = FeatureFactory(source_type=st, source_id="sid0")
+    feature.tags.add(TagFactory(id="tag:1", name="Tag 1"))
+
+    executed = api_client.execute(
+        """
+    query TagsAndFeatures {
+      tags {
+        id
+        name
+        features {
+          edges {
+            node {
+              properties {
+                ahtiId
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+    )
+    snapshot.assert_match(executed)


### PR DESCRIPTION
This PR adds a separate query for retrieving tags. Also we allow fetching features through tags i.e. features related to a specific tag.