### PR TITLE
AHTI-349 | Import translations for features from MyHelsinki

### DIFF
--- a/features/importers/myhelsinki_places/app_settings.py
+++ b/features/importers/myhelsinki_places/app_settings.py
@@ -1,7 +1,7 @@
-import json
 import sys
-from pathlib import PurePath
 from typing import Iterable, Mapping
+
+from utils.utils import read_json_file
 
 
 class AppSettings:
@@ -86,9 +86,7 @@ class AppSettings:
         )
 
 
-path = PurePath(__file__).parent.joinpath("config.json")
-with open(path.as_posix(), "r") as f:
-    config = json.loads(f.read())
+config = read_json_file(__file__, "config.json")
 
 # Ugly? Guido recommends this himself ...
 # http://mail.python.org/pipermail/python-ideas/2012-May/014969.html

--- a/features/importers/myhelsinki_places/app_settings.py
+++ b/features/importers/myhelsinki_places/app_settings.py
@@ -35,6 +35,17 @@ class AppSettings:
         return self._setting("API_CALLS", self.config["api_calls"])
 
     @property
+    def ADDITIONAL_LANGUAGES(self) -> Iterable[str]:
+        """Additional languages to import besides Finnish (`fi`).
+
+        Example:
+        additional_languages = ["en", "sv"]
+        """
+        return self._setting(
+            "ADDITIONAL_LANGUAGES", self.config["additional_languages"]
+        )
+
+    @property
     def TAG_CONFIG(self) -> Mapping:
         """Tag mapping configuration.
 

--- a/features/importers/myhelsinki_places/config.json
+++ b/features/importers/myhelsinki_places/config.json
@@ -1,4 +1,5 @@
 {
+  "additional_languages": ["en", "sv"],
   "api_calls":  [
     {"tags_search": ["MainAttraction", "Island", "Seaside", "Sea", "IslandRestaurant", "IceSwimming", "Beach", "Sauna", "Viewpoint", "Harbour", "Park", "Garden", "Canoeing", "Sup" ]},
     {"distance_filter": "60.118592, 24.753357, 5"},

--- a/features/importers/myhelsinki_places/tests/conftest.py
+++ b/features/importers/myhelsinki_places/tests/conftest.py
@@ -1,7 +1,5 @@
-import json
-from pathlib import PurePath
-
 import pytest
+from utils.utils import read_json_file
 
 from features.importers.myhelsinki_places.importer import MyHelsinkiImporter
 
@@ -25,7 +23,4 @@ def importer():
 
 @pytest.fixture
 def places_response():
-    path = PurePath(__file__).parent.joinpath("responses", "places_response.json")
-    with open(path.as_posix(), "r") as f:
-        response = json.loads(f.read())
-    return response
+    return read_json_file(__file__, "responses", "places_response.json")

--- a/features/importers/myhelsinki_places/tests/conftest.py
+++ b/features/importers/myhelsinki_places/tests/conftest.py
@@ -15,6 +15,9 @@ def setup_test_environment(settings):
         {}
     ]  # Response is mocked, parameters are redundant
 
+    # Only import Finnish on tests by default
+    settings.MYHELSINKI_PLACES_ADDITIONAL_LANGUAGES = []
+
 
 @pytest.fixture
 def importer():
@@ -24,3 +27,11 @@ def importer():
 @pytest.fixture
 def places_response():
     return read_json_file(__file__, "responses", "places_response.json")
+
+
+@pytest.fixture
+def translations_responses():
+    return {
+        "en": read_json_file(__file__, "responses", "places_en.json"),
+        "sv": read_json_file(__file__, "responses", "places_sv.json"),
+    }

--- a/features/importers/myhelsinki_places/tests/responses/places_en.json
+++ b/features/importers/myhelsinki_places/tests/responses/places_en.json
@@ -1,0 +1,202 @@
+{
+  "meta": {
+    "count": "1"
+  },
+  "data": [
+    {
+      "id": "416",
+      "name": {
+        "fi": "Suomenlinnan merilinnoitus",
+        "en": "Suomenlinna Sea Fortress",
+        "sv": "Sveaborgs sjöfästning",
+        "zh": "芬兰堡海上要塞"
+      },
+      "source_type": {
+        "id": 2,
+        "name": "Matko"
+      },
+      "info_url": "http://www.suomenlinna.fi",
+      "modified_at": "2020-03-19T13:49:16.000Z",
+      "location": {
+        "lat": 60.14891815185547,
+        "lon": 24.984798431396484,
+        "address": {
+          "street_address": "Suomenlinna",
+          "postal_code": "00190",
+          "locality": "Helsinki"
+        }
+      },
+      "description": {
+        "intro": null,
+        "body": "A Unesco World Heritage Site, Suomenlinna sea fortress is one of the most popular tourism destinations in Finland. Suomenlinna is also a suburb of Helsinki with around 800 residents. The fortress was shaped by three historic eras when it helped to defend first Sweden, then Russia and ultimately Finland. There are six kilometers of walls, 100 cannons, exciting tunnels and beautiful parks in the fortress. There are also museums, guided tours, events and restaurants in Suomenlinna. \r\n\r\nGuided walking tours are arranged during weekends in September-May, and daily during June-August. In summer also theme tours. Tickets can be bought at the Suomenlinna Museum or online (www.suomenlinnatours.com).\r\n\r\nThe fortress is easily accessed all year by public transport (HSL) ferry from the Market Square. The travelling time is approx.15minutes. In summer, from May to September, also JT-Line waterbuses operate to Suomenlinna.",
+        "images": [
+          {
+            "url": "https://edit.myhelsinki.fi/sites/default/files/styles/api_1980x1020/public/2018-09/suomenlinna_kesalla_suomen_ilmakuva_suomenlinnan_hoitokunta_location_only.jpg?h=deaec4b9&itok=fh-Wj_dU",
+            "copyright_holder": "Suomen Ilmakuva / Suomenlinnan hoitokunta",
+            "license_type": {
+              "id": 2,
+              "name": "MyHelsinki license type A"
+            }
+          },
+          {
+            "url": "https://edit.myhelsinki.fi/sites/default/files/styles/api_1980x1020/public/2018-09/suomenlinna_aino_heininen_suomenlinnan_hoitokunta_location_only.jpg?h=a77b26fc&itok=55YR1tIm",
+            "copyright_holder": "Aino Heininen / Suomenlinnan hoitokunta",
+            "license_type": {
+              "id": 2,
+              "name": "MyHelsinki license type A"
+            }
+          },
+          {
+            "url": "https://edit.myhelsinki.fi/sites/default/files/styles/api_1980x1020/public/2018-09/suomenlinna_suomen_ilmakuva_suomenlinnan_hoitokunta_location_only.jpg?h=603de84b&itok=L7heeTHT",
+            "copyright_holder": "Suomen Ilmakuva / Suomenlinnan hoitokunta",
+            "license_type": {
+              "id": 2,
+              "name": "MyHelsinki license type A"
+            }
+          }
+        ]
+      },
+      "tags": [
+        {
+          "id": "matko2:25",
+          "name": "Church"
+        },
+        {
+          "id": "matko2:122",
+          "name": "Free"
+        },
+        {
+          "id": "matko2:240",
+          "name": "Family"
+        },
+        {
+          "id": "matko2:47",
+          "name": "Island"
+        },
+        {
+          "id": "matko2:a-:Curated",
+          "name": "Curated"
+        },
+        {
+          "id": "matko1:4",
+          "name": "SIGHTS & ATTRACTIONS"
+        },
+        {
+          "id": "matko2:218",
+          "name": "Viewpoint"
+        },
+        {
+          "id": "matko2:21",
+          "name": "Art"
+        },
+        {
+          "id": "matko2:251",
+          "name": "Monument"
+        },
+        {
+          "id": "matko2:22",
+          "name": "Gallery"
+        },
+        {
+          "id": "matko2:15",
+          "name": "Banquet"
+        },
+        {
+          "id": "matko2:165",
+          "name": "Activity"
+        },
+        {
+          "id": "matko2:77",
+          "name": "History"
+        },
+        {
+          "id": "matko2:24",
+          "name": "Architecture"
+        },
+        {
+          "id": "matko2:181",
+          "name": "Sea"
+        },
+        {
+          "id": "matko2:19",
+          "name": "MainAttraction"
+        },
+        {
+          "id": "matko2:20",
+          "name": "Park"
+        },
+        {
+          "id": "matko2:74",
+          "name": "Nature"
+        }
+      ],
+      "opening_hours": {
+        "hours": [
+          {
+            "weekday_id": 1,
+            "opens": null,
+            "closes": null,
+            "open24h": false
+          },
+          {
+            "weekday_id": 2,
+            "opens": null,
+            "closes": null,
+            "open24h": false
+          },
+          {
+            "weekday_id": 3,
+            "opens": null,
+            "closes": null,
+            "open24h": false
+          },
+          {
+            "weekday_id": 4,
+            "opens": null,
+            "closes": null,
+            "open24h": false
+          },
+          {
+            "weekday_id": 5,
+            "opens": null,
+            "closes": null,
+            "open24h": false
+          },
+          {
+            "weekday_id": 6,
+            "opens": null,
+            "closes": null,
+            "open24h": false
+          },
+          {
+            "weekday_id": 7,
+            "opens": null,
+            "closes": null,
+            "open24h": false
+          }
+        ],
+        "openinghours_exception": "Suomenlinna island is open all year. Please see the opening hours of the services on the island on the webpage of Suomenlinna."
+      }
+    }
+  ],
+  "tags": {
+    "matko1:4": "SIGHTS & ATTRACTIONS",
+    "matko2:122": "Free",
+    "matko2:15": "Banquet",
+    "matko2:165": "Activity",
+    "matko2:181": "Sea",
+    "matko2:19": "MainAttraction",
+    "matko2:20": "Park",
+    "matko2:21": "Art",
+    "matko2:218": "Viewpoint",
+    "matko2:22": "Gallery",
+    "matko2:24": "Architecture",
+    "matko2:240": "Family",
+    "matko2:25": "Church",
+    "matko2:251": "Monument",
+    "matko2:47": "Island",
+    "matko2:74": "Nature",
+    "matko2:77": "History",
+    "matko2:a-:Curated": "Curated"
+  }
+}

--- a/features/importers/myhelsinki_places/tests/responses/places_response.json
+++ b/features/importers/myhelsinki_places/tests/responses/places_response.json
@@ -1,6 +1,6 @@
 {
   "meta": {
-    "count": "2"
+    "count": "3"
   },
   "data": [
     {

--- a/features/importers/myhelsinki_places/tests/responses/places_sv.json
+++ b/features/importers/myhelsinki_places/tests/responses/places_sv.json
@@ -1,0 +1,202 @@
+{
+  "meta": {
+    "count": "1"
+  },
+  "data": [
+    {
+      "id": "416",
+      "name": {
+        "fi": "Suomenlinnan merilinnoitus",
+        "en": "Suomenlinna Sea Fortress",
+        "sv": "Sveaborgs sjöfästning",
+        "zh": "芬兰堡海上要塞"
+      },
+      "source_type": {
+        "id": 2,
+        "name": "Matko"
+      },
+      "info_url": "http://www.suomenlinna.fi",
+      "modified_at": "2020-03-19T13:49:16.000Z",
+      "location": {
+        "lat": 60.14891815185547,
+        "lon": 24.984798431396484,
+        "address": {
+          "street_address": "Suomenlinna",
+          "postal_code": "00190",
+          "locality": "Helsinki"
+        }
+      },
+      "description": {
+        "intro": null,
+        "body": "Sveaborg är ett magnifikt Unescos världsarvsobjekt och ett av de mest populära besöksmålen i Finland. Sveaborg är också en del av Helsingfors med cirka 800 invånare. Fästningen har fått sin nuvarande form via olika historiska faser som en del av det svenska, ryska och finländska försvarssystemet. Det finns 6 km murar, 100 kanoner, spännande tunnlar och vackra parkområden i Sveaborg. Fästningen är med sina museer, guidade rundvandringar, evenemang och restauranger en minnesvärd upplevelse för besökare i alla åldrar. \r\n\r\nGuidade rundvandringar ordnas i september-maj på veckosluten samt i juni-augusti dagligen. Under sommarmånaderna ordnas även specialguidningar. Biljetter kan man köpa från Sveaborgsmuseet eller på förhand på nätet (www.suomenlinnatours.com).\r\n\r\nFästningen är lätt tillgänglig året runt med HRT:s färja från Salutorget, restiden är ca. 15minuter. Sommartid, från maj till september, trafikerar även en vattenbuss.",
+        "images": [
+          {
+            "url": "https://edit.myhelsinki.fi/sites/default/files/styles/api_1980x1020/public/2018-09/suomenlinna_kesalla_suomen_ilmakuva_suomenlinnan_hoitokunta_location_only.jpg?h=deaec4b9&itok=fh-Wj_dU",
+            "copyright_holder": "Suomen Ilmakuva / Suomenlinnan hoitokunta",
+            "license_type": {
+              "id": 2,
+              "name": "MyHelsinki license type A"
+            }
+          },
+          {
+            "url": "https://edit.myhelsinki.fi/sites/default/files/styles/api_1980x1020/public/2018-09/suomenlinna_aino_heininen_suomenlinnan_hoitokunta_location_only.jpg?h=a77b26fc&itok=55YR1tIm",
+            "copyright_holder": "Aino Heininen / Suomenlinnan hoitokunta",
+            "license_type": {
+              "id": 2,
+              "name": "MyHelsinki license type A"
+            }
+          },
+          {
+            "url": "https://edit.myhelsinki.fi/sites/default/files/styles/api_1980x1020/public/2018-09/suomenlinna_suomen_ilmakuva_suomenlinnan_hoitokunta_location_only.jpg?h=603de84b&itok=L7heeTHT",
+            "copyright_holder": "Suomen Ilmakuva / Suomenlinnan hoitokunta",
+            "license_type": {
+              "id": 2,
+              "name": "MyHelsinki license type A"
+            }
+          }
+        ]
+      },
+      "tags": [
+        {
+          "id": "matko2:25",
+          "name": "Church"
+        },
+        {
+          "id": "matko2:122",
+          "name": "Free"
+        },
+        {
+          "id": "matko2:240",
+          "name": "Family"
+        },
+        {
+          "id": "matko2:47",
+          "name": "Island"
+        },
+        {
+          "id": "matko2:a-:Curated",
+          "name": "Curated"
+        },
+        {
+          "id": "matko1:4",
+          "name": "SIGHTS & ATTRACTIONS"
+        },
+        {
+          "id": "matko2:218",
+          "name": "Viewpoint"
+        },
+        {
+          "id": "matko2:21",
+          "name": "Art"
+        },
+        {
+          "id": "matko2:251",
+          "name": "Monument"
+        },
+        {
+          "id": "matko2:22",
+          "name": "Gallery"
+        },
+        {
+          "id": "matko2:15",
+          "name": "Banquet"
+        },
+        {
+          "id": "matko2:165",
+          "name": "Activity"
+        },
+        {
+          "id": "matko2:77",
+          "name": "History"
+        },
+        {
+          "id": "matko2:24",
+          "name": "Architecture"
+        },
+        {
+          "id": "matko2:181",
+          "name": "Sea"
+        },
+        {
+          "id": "matko2:19",
+          "name": "MainAttraction"
+        },
+        {
+          "id": "matko2:20",
+          "name": "Park"
+        },
+        {
+          "id": "matko2:74",
+          "name": "Nature"
+        }
+      ],
+      "opening_hours": {
+        "hours": [
+          {
+            "weekday_id": 1,
+            "opens": null,
+            "closes": null,
+            "open24h": false
+          },
+          {
+            "weekday_id": 2,
+            "opens": null,
+            "closes": null,
+            "open24h": false
+          },
+          {
+            "weekday_id": 3,
+            "opens": null,
+            "closes": null,
+            "open24h": false
+          },
+          {
+            "weekday_id": 4,
+            "opens": null,
+            "closes": null,
+            "open24h": false
+          },
+          {
+            "weekday_id": 5,
+            "opens": null,
+            "closes": null,
+            "open24h": false
+          },
+          {
+            "weekday_id": 6,
+            "opens": null,
+            "closes": null,
+            "open24h": false
+          },
+          {
+            "weekday_id": 7,
+            "opens": null,
+            "closes": null,
+            "open24h": false
+          }
+        ],
+        "openinghours_exception": "Sveaborg är en av Helsingfors stadsdelar och har öppet året om. Vänligen se tjänsternas öppettider från hemsidan."
+      }
+    }
+  ],
+  "tags": {
+    "matko1:4": "SIGHTS & ATTRACTIONS",
+    "matko2:122": "Free",
+    "matko2:15": "Banquet",
+    "matko2:165": "Activity",
+    "matko2:181": "Sea",
+    "matko2:19": "MainAttraction",
+    "matko2:20": "Park",
+    "matko2:21": "Art",
+    "matko2:218": "Viewpoint",
+    "matko2:22": "Gallery",
+    "matko2:24": "Architecture",
+    "matko2:240": "Family",
+    "matko2:25": "Church",
+    "matko2:251": "Monument",
+    "matko2:47": "Island",
+    "matko2:74": "Nature",
+    "matko2:77": "History",
+    "matko2:a-:Curated": "Curated"
+  }
+}

--- a/features/importers/myhelsinki_places/tests/test_import_translations.py
+++ b/features/importers/myhelsinki_places/tests/test_import_translations.py
@@ -1,0 +1,55 @@
+import pytest
+from utils.pytest import pytest_regex
+
+from features.importers.myhelsinki_places.importer import MyHelsinkiPlacesClient
+from features.models import Feature
+
+PLACES_URL = MyHelsinkiPlacesClient.base_url + MyHelsinkiPlacesClient.places_url
+
+
+@pytest.fixture(autouse=True)
+def setup_test_translations(settings):
+    settings.MYHELSINKI_PLACES_ADDITIONAL_LANGUAGES = ["en", "sv"]
+
+
+def test_feature_translations_are_imported(
+    requests_mock, importer, places_response, translations_responses
+):
+    requests_mock.get(f"{PLACES_URL}?language_filter=fi", json=places_response)
+    requests_mock.get(
+        f"{PLACES_URL}?language_filter=en", json=translations_responses["en"]
+    )
+    requests_mock.get(
+        f"{PLACES_URL}?language_filter=sv", json=translations_responses["sv"]
+    )
+
+    importer.import_features()
+
+    feature = Feature.objects.get(source_id="416")  # Suomenlinna
+    ohp = feature.opening_hours_periods.first()
+
+    assert feature.translations.all().count() == 3
+    assert ohp.translations.all().count() == 3
+
+    feature.set_current_language("fi")
+    ohp.set_current_language("fi")
+    assert feature.name == "Suomenlinnan merilinnoitus"
+    assert feature.description == pytest_regex(
+        "^Suomenlinnan merilinnoitus on upea Unescon.*"
+    )
+    assert feature.url == "http://www.suomenlinna.fi"
+    assert ohp.comment == pytest_regex("^Suomenlinna on.*")
+
+    feature.set_current_language("en")
+    ohp.set_current_language("en")
+    assert feature.name == "Suomenlinna Sea Fortress"
+    assert feature.description == pytest_regex("^A Unesco World Heritage Site.*")
+    assert feature.url == "http://www.suomenlinna.fi"
+    assert ohp.comment == pytest_regex("^Suomenlinna island.*")
+
+    feature.set_current_language("sv")
+    ohp.set_current_language("sv")
+    assert feature.name == "Sveaborgs sjöfästning"
+    assert feature.description == pytest_regex("^Sveaborg är ett magnifikt Unescos.*")
+    assert feature.url == "http://www.suomenlinna.fi"
+    assert ohp.comment == pytest_regex("^Sveaborg är.*")

--- a/features/importers/venepaikka_harbors/app_settings.py
+++ b/features/importers/venepaikka_harbors/app_settings.py
@@ -1,7 +1,7 @@
-import json
 import sys
-from pathlib import PurePath
 from typing import Mapping
+
+from utils.utils import read_json_file
 
 
 class AppSettings:
@@ -68,9 +68,7 @@ class AppSettings:
         return self._setting("MOORING_MAPPING", self.config["mooring_mapping"])
 
 
-path = PurePath(__file__).parent.joinpath("config.json")
-with open(path.as_posix(), "r") as f:
-    config = json.loads(f.read())
+config = read_json_file(__file__, "config.json")
 
 # Ugly? Guido recommends this himself ...
 # http://mail.python.org/pipermail/python-ideas/2012-May/014969.html

--- a/features/importers/venepaikka_harbors/importer.py
+++ b/features/importers/venepaikka_harbors/importer.py
@@ -128,7 +128,6 @@ class VenepaikkaImporter(FeatureImporterBase):
             "mapped_at": timezone.now(),
             "source_modified_at": timezone.now(),
             "geometry": Point(harbor["lon"], harbor["lat"], srid=settings.DEFAULT_SRID),
-            "source_type": st,
         }
         feature, created = Feature.objects.language("fi").update_or_create(
             source_type=st, source_id=harbor["id"], defaults=values,

--- a/features/importers/venepaikka_harbors/tests/conftest.py
+++ b/features/importers/venepaikka_harbors/tests/conftest.py
@@ -1,7 +1,5 @@
-import json
-from pathlib import PurePath
-
 import pytest
+from utils.utils import read_json_file
 
 from features.importers.venepaikka_harbors.importer import VenepaikkaImporter
 
@@ -18,7 +16,4 @@ def importer():
 
 @pytest.fixture
 def harbors_response():
-    path = PurePath(__file__).parent.joinpath("responses", "harbors_response.json")
-    with open(path.as_posix(), "r") as f:
-        response = json.loads(f.read())
-    return response
+    return read_json_file(__file__, "responses", "harbors_response.json")

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -1,0 +1,15 @@
+import json
+from pathlib import PurePath
+
+
+def read_json_file(main: str, *args: str) -> dict:
+    """Read and return the JSON content from a file.
+
+    :param main: Path to which the JSON is relatively located (e.g. `__file__`)
+    :param args: Parts of the path ending with the file (e.g. `"response", "r.json"`)
+    :return: Dict containing file's JSON content.
+    """
+    path = PurePath(main).parent.joinpath(*args)
+    with open(path.as_posix(), "r") as f:
+        content = json.loads(f.read())
+    return content


### PR DESCRIPTION
## Description :sparkles:

Translations for features from MyHelsinki are fetched by making the same api calls with a different language filter. This returns features which have translations for the given language. Only translated fields are updated when translations are fetched.

- Import English and Swedish translations for features
- Add MyHelsinki responses with translations for testing
- Add setting for importing additional translations from MyHelsinki
- Remove redundant source_type from importers

Refs AHTI-349

## Issues :bug:
### Closes :no_good_woman:
**[AHTI-349](https://helsinkisolutionoffice.atlassian.net/browse/AHTI-349):** Import all language versions from MyHelsinki

## Manual testing :construction_worker_man:

```graphql
{
  features {
    edges {
      node {
        id
        geometry {
          coordinates
        }
        properties {
          translations {
            languageCode
            name
            url
            description
          }
        }
      }
    }
  }
}
```